### PR TITLE
WIP: feat: Add ColBERT

### DIFF
--- a/retrieval/colbert_index.py
+++ b/retrieval/colbert_index.py
@@ -1,0 +1,90 @@
+"""This is currently under progress pending the RAGatouille overhaul. The script is not meant to be used within the MTEB Arena Space.
+However, it is fully functional and can be used as a reference to re-create the ColBERT indexes used in Arena."""
+
+import os
+import argparse
+from colbert.infra import ColBERTConfig
+from colbert import Indexer
+import srsly
+from .common import load_passages_from_hf
+
+CORPORA = {
+    "wikipedia": {
+        "name": "mteb/arena-wikipedia-7-15-24",
+        "columns": {"id": "_id", "text": "text", "title": "title"},
+    },
+    "arxiv": {
+        "name": "mteb/arena-arxiv-7-2-24",
+        "columns": {"id": "_id", "abstract": "text", "title": "title"},
+    },
+    "stackexchange": {
+        "name": "mteb/arena-stackexchange",
+        "columns": {"id": "_id", "text": "text"},
+    },
+}
+
+
+def make_passage(doc):
+    if "title" in doc:
+        return doc["title"] + " " + doc["text"]
+    return doc["text"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="ColBERT indexing script")
+    parser.add_argument(
+        "--export-mappings",
+        action="store_true",
+        default=False,
+        help="Export document mappings",
+    )
+    parser.add_argument(
+        "--export-dir",
+        type=str,
+        default="./data/",
+        help="Directory to export mappings to",
+    )
+
+    args = parser.parse_args()
+    data = {}
+    for corpus in CORPORA.keys():
+        data[corpus] = load_passages_from_hf(corpus)
+
+    models = [
+        "/home/azureuser/colbertv2.5_en/FINAL_MODEL_3",
+    ]
+
+    for dataset_name, passages in data.items():
+        docs = [make_passage(doc) for doc in passages]
+        if args.export_mappings:
+            int2doc = {}
+            int2docid = {}
+            for i, doc in enumerate(passages):
+                int2doc[i] = docs[i]
+                int2docid[i] = doc["_id"]
+            srsly.write_json(
+                os.path.join(args.export_dir, f"{dataset_name}_int2doc.json"), int2doc
+            )
+            srsly.write_json(
+                os.path.join(args.export_dir, f"{dataset_name}_int2docid.json"),
+                int2docid,
+            )
+        print(f"Indexing {len(docs)} documents for {dataset_name}", flush=True)
+
+        config = ColBERTConfig(
+            nbits=2,
+            nranks=1,
+            root=".experiments/",
+            avoid_fork_if_possible=True,
+            overwrite=True,
+            kmeans_niters=10,
+            bsize=512,
+            index_bsize=512,
+            doc_maxlen=512,
+        )
+        indexer = Indexer(
+            checkpoint="answerdotai/AnswerAI-ColBERTv2.5-small", config=config
+        )
+        indexer.index(
+            name=f"{dataset_name}_V1_ColBERTv2.5-small", collection=docs, overwrite=True
+        )


### PR DESCRIPTION
Hey @Muennighoff!

Just the indexing code for now (will add the rest tomorrow), but opening the draft PR in case you wanted to take a look at this before the rest comes in!


**Goal of the PR**

Add support for ColBERT models, starting with Answer.AI's ColBERTv2.5-small via an API Answer will host (discussed with @ okhat who's also okay with this being the first ColBERT representative), in order to see how multi-vector models of various sizes fare on this benchmark. The querying mechanism is very simple and lives at [AnswerDotAI/mteb_arena_colbert_api](https://github.com/AnswerDotAI/mteb_arena_colbert_api)

**Changes**

- The PR relies on an external API, where the index is hosted and queried, and which will simply return documents. It doesn't change the logic of any existing mechanisms.
- It adds the ColBERT indexing code for full reproducibility
- TODO: It adds the querying mechanism, using API calls to fetch the highest scoring document for a given query.
- TODO: It adds utilities to download the pre-built indexes from Wikipedia to be able to query them locally.